### PR TITLE
adding create subcommand

### DIFF
--- a/cmd/mpas/config/config.go
+++ b/cmd/mpas/config/config.go
@@ -5,6 +5,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/open-component-model/mpas/internal/env"
 	"github.com/open-component-model/mpas/internal/printer"
 	"github.com/spf13/pflag"
@@ -17,6 +19,8 @@ type MpasConfig struct {
 	Printer *printer.Printer
 	// Timeout is the timeout to use for operations.
 	Timeout string
+	// PollInterval is used for Api call where we wait on a resource to be ready.
+	PollInterval time.Duration
 	// DockerconfigPath is the path to the docker config file.
 	DockerconfigPath string
 	// KubeConfigArgs are the kubeconfig arguments.
@@ -40,18 +44,31 @@ func (m *MpasConfig) AddFlags(flags *pflag.FlagSet) {
 
 // BootstrapConfig is the configuration shared by the bootstrap commands.
 type BootstrapConfig struct {
-	Components            []string
-	Owner                 string
-	Repository            string
-	FromFile              string
-	Registry              string
-	Hostname              string
-	Path                  string
-	Interval              string
+	// Components is the list of components to install.
+	Components []string
+	// Owner is the owner of the management repository.
+	Owner string
+	// Repository is the name of the management repository.
+	Repository string
+	// FromFile is the path to a file containing the bootstrap component in archive format.
+	FromFile string
+	// Registry is the registry to use for the bootstrap components
+	Registry string
+	// Hostname is the hostname of the Git provider.
+	Hostname string
+	// Path is the target path to use in the management repository to store the bootstrap component.
+	Path string
+	// Interval is the interval to use to sync the bootstrap component.
+	Interval string
+	// CommitMessageAppendix is the appendix to add to the commit message
+	// for example to skip CI
 	CommitMessageAppendix string
-	Private               bool
-	GenerateSelfSigned    bool
-	CaFile                string
+	// Private indicates whether the management repository should be private.
+	Private bool
+	// GenerateSelfSigned defines if a developer certificate has to be provided or not
+	GenerateSelfSigned bool
+	// CaFile defines and optional root certificate for the git repository used by flux.
+	CaFile string
 }
 
 // AddFlags adds the bootstrap flags to the given flag set.
@@ -92,4 +109,96 @@ type GiteaConfig struct {
 func (g *GiteaConfig) AddFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&g.Personal, "personal", false, "The personal access token to use to access the Gitea API")
 	g.BootstrapConfig.AddFlags(flags)
+}
+
+// CreateConfig is the configuration shared by the create commands.
+type CreateConfig struct {
+	Prune    bool
+	Interval string
+}
+
+// AddFlags adds the create flags to the given flag set.
+func (c *CreateConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.BoolVar(&c.Prune, "prune", false, "Whether to prune the resource under deletion")
+	flags.StringVar(&c.Interval, "interval", "5m", "The interval to use to sync the resource")
+}
+
+// ProjectConfig is the configuration for the create project command.
+type ProjectConfig struct {
+	CreateConfig
+	Provider            string
+	Owner               string
+	Branch              string
+	Visibility          string
+	Personal            bool
+	Domain              string
+	Maintainers         []string
+	Email               string
+	Message             string
+	Author              string
+	AlreadyExistsPolicy string
+	SecretRef           string
+}
+
+// AddFlags adds the project flags to the given flag set.
+func (p *ProjectConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&p.Provider, "provider", "", "The provider to use to create the project, e.g. github")
+	flags.StringVar(&p.Owner, "owner", "", "The owner of the project")
+	flags.StringVar(&p.Branch, "branch", "", "The branch to use for the project")
+	flags.StringVar(&p.Visibility, "visibility", "", "The visibility of the project")
+	flags.BoolVar(&p.Personal, "personal", false, "The personal access token to use to access the Gitea API")
+	flags.StringVar(&p.Domain, "domain", "", "The domain to use for the project")
+	flags.StringSliceVar(&p.Maintainers, "maintainers", []string{}, "The maintainers of the project")
+	flags.StringVar(&p.Email, "email", "", "The email to use for templating commit messages")
+	flags.StringVar(&p.Message, "message", "", "The message to use for templating commit messages")
+	flags.StringVar(&p.Author, "author", "", "The author to use for templating commit messages")
+	flags.StringVar(&p.AlreadyExistsPolicy, "already-exists-policy", "", "The policy to use when the project already exists")
+	flags.StringVar(&p.SecretRef, "secret-ref", "", "The name of an existing secret to use for authentication to the provider")
+	p.CreateConfig.AddFlags(flags)
+}
+
+// ComponentSubscriptionConfig is the configuration for the create component subscription command.
+type ComponentSubscriptionConfig struct {
+	CreateConfig
+	Component            string
+	Semver               string
+	SourceUrl            string
+	SourceSecretRef      string
+	DestinationUrl       string
+	DestinationSecretRef string
+	ServiceAccount       string
+	Verify               []string
+}
+
+// AddFlags adds the component subscription flags to the given flag set.
+func (c *ComponentSubscriptionConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&c.Component, "component", "", "The component to subscribe to")
+	flags.StringVar(&c.Semver, "semver", "", "The semver constraint to use for the component")
+	flags.StringVar(&c.SourceUrl, "source-url", "", "The source URL to use for the component")
+	flags.StringVar(&c.SourceSecretRef, "source-secret-ref", "", "The name of an existing secret to use for authentication to the source")
+	flags.StringVar(&c.DestinationUrl, "target-url", "", "The target URL to use for the component")
+	flags.StringVar(&c.DestinationSecretRef, "target-secret-ref", "", "The name of an existing secret to use for authentication to the target")
+	flags.StringVar(&c.ServiceAccount, "service-account", "", "The service account to use for the component")
+	flags.StringSliceVar(&c.Verify, "verify", []string{}, "The public keys to use to verify the component, e.g. key1:pubkey1,key2:pubkey2")
+	c.CreateConfig.AddFlags(flags)
+}
+
+// ProductDeploymentGeneratorConfig is the configuration for the create product generator command.
+type ProductDeploymentGeneratorConfig struct {
+	CreateConfig
+	SubscriptionName      string
+	SubscriptionNamespace string
+	RepositoryName        string
+	RepositoryNamespace   string
+	ServiceAccount        string
+}
+
+// AddFlags adds the product generator flags to the given flag set.
+func (p *ProductDeploymentGeneratorConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&p.SubscriptionName, "subscription-name", "", "The name of the component subscription")
+	flags.StringVar(&p.SubscriptionNamespace, "subscription-namespace", "", "The namespace of the component subscription")
+	flags.StringVar(&p.RepositoryName, "repository-name", "", "The name of the repository")
+	flags.StringVar(&p.RepositoryNamespace, "repository-namespace", "", "The namespace of the repository")
+	flags.StringVar(&p.ServiceAccount, "service-account", "", "The service account to use for the component")
+	p.CreateConfig.AddFlags(flags)
 }

--- a/cmd/mpas/create.go
+++ b/cmd/mpas/create.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/open-component-model/mpas/cmd/mpas/config"
+	"github.com/open-component-model/mpas/cmd/mpas/create"
+	"github.com/spf13/cobra"
+)
+
+// NewCreate returns a new cobra.Command to create resources
+func NewCreate(cfg *config.MpasConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create [resources] [flags]",
+		Short: "create a resource in the Kubernetes cluster.",
+		Long:  "create a resource in the Kubernetes cluster.",
+	}
+
+	cmd.AddCommand(NewCreateProject(cfg))
+	cmd.AddCommand(NewCreateComponentSubscription(cfg))
+	cmd.AddCommand(NewCreateProductDeploymentGenerator(cfg))
+
+	return cmd
+}
+
+// NewCreateProject returns a new cobra.Command to create a project
+func NewCreateProject(cfg *config.MpasConfig) *cobra.Command {
+	c := &config.ProjectConfig{}
+	cmd := &cobra.Command{
+		Use:   "project [flags]",
+		Short: "Create a project resource.",
+		Example: `  - Create a project in namespace my-namespace
+    mpas create project my-project --owner=myUser --personal --provider=github, --secret-ref=github-secret --namespace my-namespace=my-project
+
+    - Create a project with a private user repository
+    mpas create project my-project --owner=myUser --personal --provider=github, --secret-ref=github-secret --visibility=private --namespace my-namespace=my-project
+
+    - Create a project an export the project to a file
+    mpas create project my-project --owner=myUser --personal --provider=github, --secret-ref=github-secret --namespace my-namespace=my-project --export > my-project.yaml
+`,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			name := args[0]
+			if name == "" {
+				return fmt.Errorf("no project name specified, see mpas create project --help for more information")
+			}
+
+			p := create.NewProjectCmd(name, *c)
+			return p.Execute(cmd.Context(), cfg)
+		},
+	}
+
+	c.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// NewCreateComponentSubscription returns a new cobra.Command to create a component subscription
+func NewCreateComponentSubscription(cfg *config.MpasConfig) *cobra.Command {
+	c := &config.ComponentSubscriptionConfig{}
+	cmd := &cobra.Command{
+		Use:     "component-subscription [flags]",
+		Aliases: []string{"cs"},
+		Short:   "Create a component subscription resource.",
+		Example: `  - Create a component subscription in namespace my-namespace
+    mpas create component-subscription my-subscription --component=mpas.ocm.software/podinfo --semver=">=v1.0.0" --source-url=ghcr.io/open-component-model/mpas --source-secret-ref=github-access --namespace=my-namespace my-project
+
+    - Create a component subscription an export the project to a file
+    mpas create component-subscription my-subscription --component=mpas.ocm.software/podinfo --semver=">=v1.0.0" --source-url=ghcr.io/open-component-model/mpas --source-secret-ref=github-access --namespace my-namespace=my-project --export > my-subscription.yaml
+`,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			name := args[0]
+			if name == "" {
+				return fmt.Errorf("no component subscription name specified, see mpas create component-subscription --help for more information")
+			}
+
+			p := create.NewComponentSubscriptionCmd(name, *c)
+			return p.Execute(cmd.Context(), cfg)
+		},
+	}
+
+	c.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// NewCreateProductDeploymentGenerator returns a new cobra.Command to create a product deployment generator
+func NewCreateProductDeploymentGenerator(cfg *config.MpasConfig) *cobra.Command {
+	c := &config.ProductDeploymentGeneratorConfig{}
+	cmd := &cobra.Command{
+		Use:     "product-deployment-generator [flags]",
+		Aliases: []string{"pdg"},
+		Short:   "Create a product deployment generator resource.",
+		Example: `  - Create a product deployment generator in namespace my-namespace
+    mpas create product-deployment-generator my-product --service-account=my-sa --subscription-name=my-subscription --subscription-namespace=my-project  --namespace=my-project
+
+    - Create a product deployment generator an export the project to a file
+    mpas create product-deployment-generator my-product --service-account=my-sa --subscription-name=my-subscription --subscription-namespace=my-project  --namespace=my-project --export > my-product-generator.yaml
+`,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			name := args[0]
+			if name == "" {
+				return fmt.Errorf("no product deployment generator name specified, see mpas create product-deployment-generator --help for more information")
+			}
+
+			p := create.NewProductDeploymentGeneratorCmd(name, *c)
+			return p.Execute(cmd.Context(), cfg)
+		},
+	}
+
+	c.AddFlags(cmd.Flags())
+
+	return cmd
+}

--- a/cmd/mpas/create/create_component_subscription.go
+++ b/cmd/mpas/create/create_component_subscription.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package create
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/open-component-model/mpas/cmd/mpas/config"
+	"github.com/open-component-model/mpas/internal/kubeutils"
+	"github.com/open-component-model/mpas/internal/printer"
+	"github.com/open-component-model/mpas/internal/resource"
+	rep1alpha1 "github.com/open-component-model/replication-controller/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ComponentSubscriptionCmd defines the command for creating a component subscription.
+type ComponentSubscriptionCmd struct {
+	name string
+	config.ComponentSubscriptionConfig
+}
+
+// NewComponentSubscriptionCmd returns a new command for creating a component subscription.
+func NewComponentSubscriptionCmd(name string, c config.ComponentSubscriptionConfig) *ComponentSubscriptionCmd {
+	return &ComponentSubscriptionCmd{
+		name:                        name,
+		ComponentSubscriptionConfig: c,
+	}
+}
+
+// Execute executes the command and returns an error if one occurred.
+func (c *ComponentSubscriptionCmd) Execute(ctx context.Context, cfg *config.MpasConfig) error {
+	t, err := time.ParseDuration(cfg.Timeout)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, t)
+	defer cancel()
+
+	err = c.validate()
+	if err != nil {
+		return err
+	}
+
+	interval, err := time.ParseDuration(c.Interval)
+	if err != nil {
+		return fmt.Errorf("interval must be specified")
+	}
+
+	csub := &resource.ComponentSubscription{
+		ComponentSubscription: rep1alpha1.ComponentSubscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      c.name,
+				Namespace: *cfg.KubeConfigArgs.Namespace,
+			},
+			Spec: rep1alpha1.ComponentSubscriptionSpec{
+				Component: c.Component,
+				Interval:  metav1.Duration{Duration: interval},
+				Source: rep1alpha1.OCMRepository{
+					URL: c.SourceUrl,
+				},
+			},
+		},
+	}
+
+	if c.SourceSecretRef != "" {
+		csub.Spec.Source.SecretRef = &meta.LocalObjectReference{
+			Name: c.SourceSecretRef,
+		}
+	}
+
+	if c.DestinationUrl != "" {
+		csub.Spec.Destination = &rep1alpha1.OCMRepository{
+			URL: c.DestinationUrl,
+			SecretRef: &meta.LocalObjectReference{
+				Name: c.DestinationSecretRef,
+			},
+		}
+	}
+
+	if c.Semver != "" {
+		csub.Spec.Semver = c.Semver
+	}
+
+	if c.Verify != nil {
+		signatures := make([]rep1alpha1.Signature, len(c.Verify))
+		for _, v := range c.Verify {
+			name, pubkey := strings.Split(v, ":")[0], strings.Split(v, ":")[1]
+			signatures = append(signatures, rep1alpha1.Signature{
+				Name: name,
+				PublicKey: rep1alpha1.SecretRef{
+					SecretRef: meta.LocalObjectReference{
+						Name: pubkey,
+					},
+				},
+			})
+		}
+		csub.Spec.Verify = signatures
+	}
+
+	if c.ServiceAccount != "" {
+		csub.Spec.ServiceAccountName = c.ServiceAccount
+	}
+
+	if cfg.Export {
+		exp, err := csub.ToYamlExport()
+		if err != nil {
+			return fmt.Errorf("failed to export component subscription: %w", err)
+		}
+		cfg.Printer.Println(exp)
+		return nil
+	}
+
+	kubeClient, err := kubeutils.KubeClient(cfg.KubeConfigArgs)
+	if err != nil {
+		return err
+	}
+
+	if err := cfg.Printer.PrintSpinner(fmt.Sprintf("Creating component subscription %s in namespace %s",
+		printer.BoldBlue(csub.Name), printer.BoldBlue(csub.Namespace))); err != nil {
+		return err
+	}
+
+	if _, err := resource.ApplyAndWait(ctx, kubeClient, csub, cfg.PollInterval, t, func() error {
+		return nil
+	}); err != nil {
+		if er := cfg.Printer.StopFailSpinner(fmt.Sprintf("Creating component subscription %s in namespace %s",
+			printer.BoldBlue(csub.Name), printer.BoldBlue(csub.Namespace))); er != nil {
+			err = errors.Join(err, er)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (c *ComponentSubscriptionCmd) validate() error {
+	if c.Component == "" {
+		return fmt.Errorf("component must be specified")
+	}
+
+	if c.SourceUrl == "" {
+		return fmt.Errorf("source-url must be specified")
+	}
+
+	return nil
+}

--- a/cmd/mpas/create/create_product_generator.go
+++ b/cmd/mpas/create/create_product_generator.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package create
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	prd1alpha1 "github.com/open-component-model/mpas-product-controller/api/v1alpha1"
+	"github.com/open-component-model/mpas/cmd/mpas/config"
+	"github.com/open-component-model/mpas/internal/kubeutils"
+	"github.com/open-component-model/mpas/internal/printer"
+	"github.com/open-component-model/mpas/internal/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ProductDeploymentGeneratorCmd defines the command for creating a product deployment generator.
+type ProductDeploymentGeneratorCmd struct {
+	name string
+	config.ProductDeploymentGeneratorConfig
+}
+
+// NewPProductDeploymentGeneratorCmd returns a new command for creating a product deployment generator.
+func NewProductDeploymentGeneratorCmd(name string, p config.ProductDeploymentGeneratorConfig) *ProductDeploymentGeneratorCmd {
+	return &ProductDeploymentGeneratorCmd{
+		name:                             name,
+		ProductDeploymentGeneratorConfig: p,
+	}
+}
+
+// Execute executes the command and returns an error if one occurred.
+func (p *ProductDeploymentGeneratorCmd) Execute(ctx context.Context, cfg *config.MpasConfig) error {
+	t, err := time.ParseDuration(cfg.Timeout)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, t)
+	defer cancel()
+
+	err = p.validate()
+	if err != nil {
+		return err
+	}
+
+	interval, err := time.ParseDuration(p.Interval)
+	if err != nil {
+		return fmt.Errorf("interval must be specified")
+	}
+
+	prd := &resource.ProductDeploymentGenerator{
+		ProductDeploymentGenerator: prd1alpha1.ProductDeploymentGenerator{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      p.name,
+				Namespace: *cfg.KubeConfigArgs.Namespace,
+			},
+			Spec: prd1alpha1.ProductDeploymentGeneratorSpec{
+				SubscriptionRef: meta.NamespacedObjectReference{
+					Name:      p.SubscriptionName,
+					Namespace: p.SubscriptionNamespace,
+				},
+				Interval: metav1.Duration{
+					Duration: interval,
+				},
+				ServiceAccountName: p.ServiceAccount,
+			},
+		},
+	}
+
+	if p.RepositoryName != "" {
+		prd.Spec.RepositoryRef = &meta.LocalObjectReference{
+			Name: p.RepositoryName,
+		}
+	}
+
+	if cfg.Export {
+		exp, err := prd.ToYamlExport()
+		if err != nil {
+			return fmt.Errorf("failed to export product deployment generator: %w", err)
+		}
+		cfg.Printer.Println(exp)
+		return nil
+	}
+
+	kubeClient, err := kubeutils.KubeClient(cfg.KubeConfigArgs)
+	if err != nil {
+		return err
+	}
+
+	if err := cfg.Printer.PrintSpinner(fmt.Sprintf("Creating product deployment generator %s in namespace %s",
+		printer.BoldBlue(prd.Name), printer.BoldBlue(prd.Namespace))); err != nil {
+		return err
+	}
+
+	if _, err := resource.ApplyAndWait(ctx, kubeClient, prd, cfg.PollInterval, t, func() error {
+		return nil
+	}); err != nil {
+		if er := cfg.Printer.StopFailSpinner(fmt.Sprintf("Creating product deployment generator %s in namespace %s",
+			printer.BoldBlue(prd.Name), printer.BoldBlue(prd.Namespace))); er != nil {
+			err = errors.Join(err, er)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (p *ProductDeploymentGeneratorCmd) validate() error {
+	if p.SubscriptionName == "" || p.SubscriptionNamespace == "" {
+		return fmt.Errorf("subscription-name must be specified")
+	}
+
+	if p.ServiceAccount == "" {
+		return fmt.Errorf("service-account must be specified")
+	}
+
+	return nil
+}

--- a/cmd/mpas/create/create_project.go
+++ b/cmd/mpas/create/create_project.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package create
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	gcv1alpha1 "github.com/open-component-model/git-controller/apis/mpas/v1alpha1"
+	prj1alpha1 "github.com/open-component-model/mpas-project-controller/api/v1alpha1"
+	"github.com/open-component-model/mpas/cmd/mpas/config"
+	"github.com/open-component-model/mpas/internal/kubeutils"
+	"github.com/open-component-model/mpas/internal/printer"
+	"github.com/open-component-model/mpas/internal/resource"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ProjectCmd defines the command for creating a project.
+type ProjectCmd struct {
+	name string
+	config.ProjectConfig
+}
+
+// NewProjectCmd returns a new command for creating a project.
+func NewProjectCmd(name string, p config.ProjectConfig) *ProjectCmd {
+	return &ProjectCmd{
+		name:          name,
+		ProjectConfig: p,
+	}
+}
+
+// Execute executes the command and returns an error if one occurred.
+func (p *ProjectCmd) Execute(ctx context.Context, cfg *config.MpasConfig) error {
+	t, err := time.ParseDuration(cfg.Timeout)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, t)
+	defer cancel()
+
+	err = p.validate()
+	if err != nil {
+		return err
+	}
+
+	interval, err := time.ParseDuration(p.Interval)
+	if err != nil {
+		return fmt.Errorf("interval must be specified")
+	}
+
+	project := &resource.Project{
+		Project: prj1alpha1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      p.name,
+				Namespace: *cfg.KubeConfigArgs.Namespace,
+			},
+			Spec: prj1alpha1.ProjectSpec{
+				Git: gcv1alpha1.RepositorySpec{
+					Owner:    p.Owner,
+					Provider: p.Provider,
+					Credentials: gcv1alpha1.Credentials{
+						SecretRef: v1.LocalObjectReference{
+							Name: p.SecretRef,
+						},
+					},
+					DefaultBranch: p.Branch,
+					Interval: metav1.Duration{
+						Duration: interval,
+					},
+					Visibility:               p.Visibility,
+					IsOrganization:           !p.Personal,
+					Domain:                   p.Domain,
+					Maintainers:              p.Maintainers,
+					ExistingRepositoryPolicy: gcv1alpha1.ExistingRepositoryPolicy(p.AlreadyExistsPolicy),
+				},
+				Flux: prj1alpha1.FluxSpec{
+					Interval: metav1.Duration{
+						Duration: interval,
+					},
+				},
+				Prune: p.Prune,
+				Interval: metav1.Duration{
+					Duration: interval,
+				},
+			},
+		},
+	}
+
+	if p.Email != "" || p.Message != "" || p.Author != "" {
+		project.Spec.Git.CommitTemplate = &gcv1alpha1.CommitTemplate{
+			Email:   p.Email,
+			Message: p.Message,
+			Name:    p.Author,
+		}
+	}
+
+	if cfg.Export {
+		exp, err := project.ToYamlExport()
+		if err != nil {
+			return fmt.Errorf("failed to export project: %w", err)
+		}
+		cfg.Printer.Println(exp)
+		return nil
+	}
+
+	kubeClient, err := kubeutils.KubeClient(cfg.KubeConfigArgs)
+	if err != nil {
+		return err
+	}
+
+	if err := cfg.Printer.PrintSpinner(fmt.Sprintf("Creating project %s in namespace %s",
+		printer.BoldBlue(project.Name), printer.BoldBlue(project.Namespace))); err != nil {
+		return err
+	}
+
+	if _, err := resource.ApplyAndWait(ctx, kubeClient, project, cfg.PollInterval, t, func() error {
+		return nil
+	}); err != nil {
+		if er := cfg.Printer.StopFailSpinner(fmt.Sprintf("Creating project %s in namespace %s",
+			printer.BoldBlue(project.Name), printer.BoldBlue(project.Namespace))); er != nil {
+			err = errors.Join(err, er)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (p *ProjectCmd) validate() error {
+	if p.Owner == "" {
+		return fmt.Errorf("owner must be specified")
+	}
+
+	if p.Provider == "" {
+		return fmt.Errorf("provider must be specified")
+	}
+
+	if p.SecretRef == "" {
+		return fmt.Errorf("secret-ref must be specified")
+	}
+	return nil
+}

--- a/cmd/mpas/root.go
+++ b/cmd/mpas/root.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/open-component-model/mpas/cmd/mpas/config"
@@ -52,7 +53,10 @@ func New(ctx context.Context, args []string) (*cobra.Command, error) {
 	}
 	cfg.KubeConfigArgs.AddFlags(cmd.PersistentFlags())
 
+	cfg.PollInterval = 2 * time.Second
+
 	cmd.AddCommand(NewBootstrap(cfg))
+	cmd.AddCommand(NewCreate(cfg))
 
 	cmd.InitDefaultHelpCmd()
 

--- a/e2e-cli/main_test.go
+++ b/e2e-cli/main_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 // SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -11,15 +8,68 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/open-component-model/mpas/cmd/mpas/bootstrap"
+	"github.com/open-component-model/mpas/cmd/mpas/config"
+	"github.com/open-component-model/mpas/cmd/mpas/create"
 	"github.com/open-component-model/mpas/internal/env"
 	"github.com/open-component-model/ocm-e2e-framework/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var prjYaml = `---
+apiVersion: mpas.ocm.software/v1alpha1
+kind: Project
+metadata:
+  name: test
+  namespace: %s
+spec:
+  flux:
+    interval: 5m0s
+  git:
+    credentials:
+      secretRef:
+        name: test-secret
+    interval: 5m0s
+    isOrganization: false
+    owner: %s
+    provider: gitea
+  interval: 5m0s
+`
+
+var prdYaml = `---
+apiVersion: mpas.ocm.software/v1alpha1
+kind: ProductDeploymentGenerator
+metadata:
+  name: test
+  namespace: %s
+spec:
+  interval: 5m0s
+  serviceAccountName: test-sa
+  subscriptionRef:
+    name: test
+    namespace: %s
+`
+
+var csubYaml = `---
+apiVersion: delivery.ocm.software/v1alpha1
+kind: ComponentSubscription
+metadata:
+  name: test
+  namespace: %s
+spec:
+  component: mpas.ocm.software/podinfo
+  interval: 5m0s
+  semver: '>=v1.0.0'
+  source:
+    secretRef:
+      name: test-secret
+    url: ghcr.io/open-component-model/mpas
+`
 
 func TestBootstrap_github(t *testing.T) {
 	owner, token, err := retrieveBootStrapConfigVars()
@@ -50,6 +100,30 @@ func TestBootstrap_gitea(t *testing.T) {
 	bootstrapGiteaCmd, err := bootstrapGitea(owner, token, hostname)
 	require.NoError(t, err)
 	assert.NotNil(t, bootstrapGiteaCmd)
+
+	//set export falg
+	cfg.Export = true
+
+	prjOut := strings.Builder{}
+	cfg.Printer.SetOutput(&prjOut)
+	prjCmd := createProject("test", "gitea", owner, "test-secret", true)
+	err = prjCmd.Execute(context.Background(), &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(prjYaml, namespace, owner), prjOut.String())
+
+	csubOut := strings.Builder{}
+	cfg.Printer.SetOutput(&csubOut)
+	csubCmd := createComponentSubscription("test", "test-secret")
+	err = csubCmd.Execute(context.Background(), &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(csubYaml, namespace), csubOut.String())
+
+	prdOut := strings.Builder{}
+	cfg.Printer.SetOutput(&prdOut)
+	pdgCmd := createProductDeploymentGenerator("test", "test-sa")
+	err = pdgCmd.Execute(context.Background(), &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(prdYaml, namespace, namespace), prdOut.String())
 
 	// cleanup
 	ctx := context.Background()
@@ -144,4 +218,39 @@ func bootstrapGitea(owner, token, hostname string) (*bootstrap.GiteaCmd, error) 
 		return nil, fmt.Errorf("failed to execute bootstrapGiteaCmd: %w", err)
 	}
 	return &bootstrapGiteaCmd, nil
+}
+
+func createProject(name, provider, owner, secret string, personal bool) *create.ProjectCmd {
+	return create.NewProjectCmd(name, config.ProjectConfig{
+		Provider:  provider,
+		Owner:     owner,
+		SecretRef: secret,
+		Personal:  personal,
+		CreateConfig: config.CreateConfig{
+			Interval: "5m",
+		},
+	})
+}
+
+func createComponentSubscription(name, secret string) *create.ComponentSubscriptionCmd {
+	return create.NewComponentSubscriptionCmd(name, config.ComponentSubscriptionConfig{
+		Component:       "mpas.ocm.software/podinfo",
+		Semver:          ">=v1.0.0",
+		SourceUrl:       "ghcr.io/open-component-model/mpas",
+		SourceSecretRef: secret,
+		CreateConfig: config.CreateConfig{
+			Interval: "5m",
+		},
+	})
+}
+
+func createProductDeploymentGenerator(name, sa string) *create.ProductDeploymentGeneratorCmd {
+	return create.NewProductDeploymentGeneratorCmd(name, config.ProductDeploymentGeneratorConfig{
+		SubscriptionName:      name,
+		SubscriptionNamespace: namespace,
+		ServiceAccount:        sa,
+		CreateConfig: config.CreateConfig{
+			Interval: "5m",
+		},
+	})
 }

--- a/e2e-cli/suite_test.go
+++ b/e2e-cli/suite_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 // SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -11,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/open-component-model/mpas/cmd/mpas/config"
@@ -38,6 +36,7 @@ var (
 	targetPath            = "clusters/my-cluster"
 	cfg                   = config.MpasConfig{
 		Timeout:          "5m",
+		PollInterval:     5 * time.Millisecond,
 		DockerconfigPath: "~/.docker/config.json",
 		KubeConfigArgs:   genericclioptions.NewConfigFlags(false),
 		PlainHTTP:        true,
@@ -72,6 +71,9 @@ func TestMain(m *testing.M) {
 		shared.StartGitServer(namespace),
 		shared.ForwardPortForAppName("gitea", 3000, stopChannelGitea),
 	)
+
+	// set the kubeconfig namespace
+	cfg.KubeConfigArgs.Namespace = &namespace
 
 	testEnv.Finish(
 		shared.RemoveGitServer(namespace),

--- a/go.mod
+++ b/go.mod
@@ -58,15 +58,15 @@ require (
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
 	golang.org/x/term v0.11.0
 	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/api v0.28.1
-	k8s.io/apiextensions-apiserver v0.28.0
-	k8s.io/apimachinery v0.28.1
-	k8s.io/cli-runtime v0.28.1
-	k8s.io/client-go v0.28.1
+	k8s.io/api v0.28.2
+	k8s.io/apiextensions-apiserver v0.28.2
+	k8s.io/apimachinery v0.28.2
+	k8s.io/cli-runtime v0.28.2
+	k8s.io/client-go v0.28.2
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
 	oras.land/oras-go/v2 v2.2.1
 	sigs.k8s.io/cli-utils v0.35.0
-	sigs.k8s.io/controller-runtime v0.16.1
+	sigs.k8s.io/controller-runtime v0.16.2
 	sigs.k8s.io/e2e-framework v0.2.0
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3

--- a/internal/kubeutils/kubeutils.go
+++ b/internal/kubeutils/kubeutils.go
@@ -20,6 +20,7 @@ import (
 	projectv1alpha1 "github.com/open-component-model/mpas-project-controller/api/v1alpha1"
 	"github.com/open-component-model/mpas/internal/env"
 	ocmv1alpha1 "github.com/open-component-model/ocm-controller/api/v1alpha1"
+	rep1alpha1 "github.com/open-component-model/replication-controller/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -53,6 +54,7 @@ func init() {
 	apiList = append(apiList, ocmv1alpha1.AddToScheme)
 	apiList = append(apiList, productv1alpha1.AddToScheme)
 	apiList = append(apiList, projectv1alpha1.AddToScheme)
+	apiList = append(apiList, rep1alpha1.AddToScheme)
 }
 
 // NewScheme creates the Scheme methods for serializing and deserializing API objects

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -65,6 +65,10 @@ func (p *Printer) out() io.Writer {
 	return io.Discard
 }
 
+func (p *Printer) SetOutput(output io.Writer) {
+	p.output = output
+}
+
 func (p *Printer) startSpinner() error {
 	if p.spinner.Status() == yacspin.SpinnerStopped {
 		err := p.spinner.Start()

--- a/internal/resource/component_subscription.go
+++ b/internal/resource/component_subscription.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	rep1alpha1 "github.com/open-component-model/replication-controller/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Resource is an interface for Kubernetes resources.
+var _ Resource = (*ComponentSubscription)(nil)
+
+// ComponentSubscription is a wrapper around prj1alpha1.ComponentSubscription.
+type ComponentSubscription struct {
+	rep1alpha1.ComponentSubscription
+}
+
+// ToClientObject returns the component subscription as a client.Object.
+func (c *ComponentSubscription) ToClientObject() client.Object {
+	return &c.ComponentSubscription
+}
+
+// GetObservedGeneration returns the observed generation of the component subscription.
+func (c *ComponentSubscription) GetObservedGeneration() int64 {
+	return c.Status.ObservedGeneration
+}
+
+// GetGeneration returns the generation of the component subscription.
+func (c *ComponentSubscription) GetGeneration() int64 {
+	return c.Generation
+}
+
+// ToYamlExport returns the component subscription as a YAML string.
+// It can be used to export the component subscription to a file or to pass to kubectl apply.
+func (c *ComponentSubscription) ToYamlExport() (string, error) {
+	sub := c.DeepCopy()
+	gvk := rep1alpha1.GroupVersion.WithKind("ComponentSubscription")
+	sub.SetGroupVersionKind(gvk)
+	return toYamlExport(sub)
+}

--- a/internal/resource/product_generator.go
+++ b/internal/resource/product_generator.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	prd1alpha1 "github.com/open-component-model/mpas-product-controller/api/v1alpha1"
+	prj1alpha1 "github.com/open-component-model/mpas-project-controller/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Resource is an interface for Kubernetes resources.
+var _ Resource = (*ProductDeploymentGenerator)(nil)
+
+// ProductDeploymentGenerator is a wrapper around prj1alpha1.ProductDeploymentGenerator.
+type ProductDeploymentGenerator struct {
+	prd1alpha1.ProductDeploymentGenerator
+}
+
+// ToClientObject returns the project as a client.Object.
+func (p *ProductDeploymentGenerator) ToClientObject() client.Object {
+	return &p.ProductDeploymentGenerator
+}
+
+// GetObservedGeneration returns the observed generation of the project.
+func (p *ProductDeploymentGenerator) GetObservedGeneration() int64 {
+	return p.Status.ObservedGeneration
+}
+
+// GetGeneration returns the generation of the project.
+func (p *ProductDeploymentGenerator) GetGeneration() int64 {
+	return p.Generation
+}
+
+// ToYamlExport returns the project as a YAML string.
+// It can be used to export the project to a file or to pass to kubectl apply.
+func (p *ProductDeploymentGenerator) ToYamlExport() (string, error) {
+	proj := p.DeepCopy()
+	gvk := prj1alpha1.GroupVersion.WithKind("ProductDeploymentGenerator")
+	proj.SetGroupVersionKind(gvk)
+	return toYamlExport(proj)
+}

--- a/internal/resource/project.go
+++ b/internal/resource/project.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"bytes"
+	"strings"
+
+	prj1alpha1 "github.com/open-component-model/mpas-project-controller/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// Resource is an interface for Kubernetes resources.
+var _ Resource = (*Project)(nil)
+
+// Project is a wrapper around prj1alpha1.Project.
+type Project struct {
+	prj1alpha1.Project
+}
+
+// ToClientObject returns the project as a client.Object.
+func (p *Project) ToClientObject() client.Object {
+	return &p.Project
+}
+
+// GetObservedGeneration returns the observed generation of the project.
+func (p *Project) GetObservedGeneration() int64 {
+	return p.Status.ObservedGeneration
+}
+
+// GetGeneration returns the generation of the project.
+func (p *Project) GetGeneration() int64 {
+	return p.Generation
+}
+
+// ToYamlExport returns the project as a YAML string.
+// It can be used to export the project to a file or to pass to kubectl apply.
+func (p *Project) ToYamlExport() (string, error) {
+	proj := p.DeepCopy()
+	gvk := prj1alpha1.GroupVersion.WithKind("Project")
+	proj.SetGroupVersionKind(gvk)
+	return toYamlExport(proj)
+}
+
+func toYamlExport(obj interface{}) (string, error) {
+	b, err := yaml.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	b = bytes.Replace(b, []byte("  creationTimestamp: null\n"), []byte(""), 1)
+	b = bytes.Replace(b, []byte("status: {}\n"), []byte(""), 1)
+	b = bytes.TrimSpace(b)
+
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	sb.Write(b)
+
+	return sb.String(), nil
+}

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Resource is an interface for Kubernetes resources.
+type Resource interface {
+	ToClientObject() client.Object
+	GetObservedGeneration() int64
+	GetGeneration() int64
+	GetConditions() []metav1.Condition
+}
+
+// ApplyAndWait takes an object implementing client.Object and a function to mutate the object.
+// It creates or updates the object and returns the operation performed and an error if one occurred.
+// It then waits for the object to reach the desired generation and ready condition.
+func ApplyAndWait(ctx context.Context, kubeClient client.Client, resource Resource, interval, timeout time.Duration, mutateFn func() error) (string, error) {
+	name := types.NamespacedName{
+		Namespace: resource.ToClientObject().GetNamespace(),
+		Name:      resource.ToClientObject().GetName(),
+	}
+	op, err := controllerutil.CreateOrUpdate(ctx, kubeClient, resource.ToClientObject(), mutateFn)
+	if err != nil {
+		return string(op), fmt.Errorf("failed to create or update %s: %w", name, err)
+	}
+
+	err = wait.PollWithContext(ctx, interval, timeout, func(ctx context.Context) (done bool, err error) {
+		err = kubeClient.Get(ctx, name, resource.ToClientObject())
+		if err != nil {
+			return false, fmt.Errorf("failed to get %s: %w", name, err)
+		}
+
+		if resource.GetGeneration() == resource.GetObservedGeneration() {
+			if c := apimeta.FindStatusCondition(resource.GetConditions(), meta.ReadyCondition); c != nil {
+				switch c.Status {
+				case metav1.ConditionTrue:
+					return true, nil
+				case metav1.ConditionFalse:
+					return false, fmt.Errorf(c.Message)
+				}
+			}
+		}
+
+		return false, nil
+	})
+
+	return string(op), err
+}


### PR DESCRIPTION
fixes #91 #95 #97

## Description

This PR adds a `mpas create` subcommand with 3 targets for now:
- Project
- ComponentSubscription
- ProductDeploymentGenerator

The subcommand can create the objects in cluster or export generated yamls on standard ouput.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added e2e-tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for e2e-tests

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
