### PR TITLE
feat: display version of the MPAS CLI

### DIFF
--- a/cmd/mpas/root.go
+++ b/cmd/mpas/root.go
@@ -57,6 +57,7 @@ func New(ctx context.Context, args []string) (*cobra.Command, error) {
 
 	cmd.AddCommand(NewBootstrap(cfg))
 	cmd.AddCommand(NewCreate(cfg))
+	cmd.AddCommand(NewVersion(cfg))
 
 	cmd.InitDefaultHelpCmd()
 

--- a/cmd/mpas/version.go
+++ b/cmd/mpas/version.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"github.com/open-component-model/mpas/cmd/mpas/config"
+	"github.com/spf13/cobra"
+)
+
+// NewVersion returns a new cobra.Command to provide version information.
+func NewVersion(cfg *config.MpasConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "returns the version of the current binary",
+		Long:  "returns the version of the current binary",
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg.Printer.Println(Version)
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added e2e-tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for e2e-tests

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
